### PR TITLE
add support for esm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 public/daypickr*
+public/esm*

--- a/package.json
+++ b/package.json
@@ -53,5 +53,9 @@
         }
       ]
     ]
+  },
+  "exports": {
+    ".": "./public/daypickr.js",
+    "./esm": "./public/esm/index.js"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -8,3 +8,7 @@ esbuild.build({
 esbuild.build({
   ...config.browser,
 });
+
+esbuild.build({
+  ...config.esm,
+});

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -23,4 +23,11 @@ export default {
     target: 'node14',
     outfile: 'public/daypickr.js',
   },
+  esm: {
+    ...commonConfig,
+    format: 'esm',
+    platform: 'browser',
+    outfile: 'public/esm/index.js',
+    minify: false,
+  },
 };


### PR DESCRIPTION
Toto potrebujem pretoze React 19 ma problem s default importami Preact komponentov. Plus nove ODS bude ESM cize toto je jednoduche riesenie ako komponent importnut - otestovane, funguje